### PR TITLE
Increment MH version + Update api response MHC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - workflow
 
 jobs:
   release:

--- a/mount-helper-container/Makefile
+++ b/mount-helper-container/Makefile
@@ -18,7 +18,7 @@ export LINT_VERSION="1.43.0"
 GOPACKAGES=$(shell go list ./... | grep -v /vendor/ | grep -v /tests)
 
 NAME := mount-helper-container
-APP_VERSION := 1.0.0
+APP_VERSION := 0.0.2
 MAINTAINER := "IKS Storage"
 DESCRIPTION := "IBM Mount-helper-container service"
 LICENSE := "IBM"
@@ -51,7 +51,7 @@ deb-build: build-linux
 	echo "Maintainer: $(MAINTAINER)" >> $(DEBIAN_CONTROL)
 	echo "Architecture: $(DEB_ARCH)" >> $(DEBIAN_CONTROL)
 	echo "Description: $(DESCRIPTION)" >> $(DEBIAN_CONTROL)
-	echo "Depends: mount-ibmshare-1.0.0" >> $(DEBIAN_CONTROL)
+	echo "Depends: mount.ibmshare-0.0.3" >> $(DEBIAN_CONTROL)
 
 	dpkg-deb --build $(BUILD_DIR)
 	rm -rf $(BUILD_DIR)
@@ -71,7 +71,7 @@ rpm-build: build-linux
 	echo "Summary: $(DESCRIPTION)" >> $(REDHAT_SPEC)
 	echo "License: $(LICENSE)" >>  $(REDHAT_SPEC)
 	echo "BuildArch: $(RPM_ARCH)" >>  $(REDHAT_SPEC)
-	echo "Requires: mount-ibmshare" >> $(REDHAT_SPEC)
+	echo "Requires: mount.ibmshare = 0.0.3" >> $(REDHAT_SPEC)
 	echo "%define _rpmfilename $(NAME)-$(APP_VERSION).rpm" >> $(REDHAT_SPEC)
 	echo "%build" >> $(REDHAT_SPEC)
 

--- a/mount-helper-container/README.md
+++ b/mount-helper-container/README.md
@@ -6,21 +6,14 @@ This is a REST based mount-helper-container service which is used for mounting E
 
 | IKS/ROKS Version | Image/Distribution | Mount-Helper-Container Supported | 
 |------|-------|--------|
-| ROKS 4.14 | RHEL 8.9 | |
-| ROKS 4.13 | RHEL 8.8 | |
-| ROKS 4.12 | RHEL 8.8 | |
-| ROKS 4.11 | RHEL 8.8 | |
-| IKS 1.28 | Ubuntu 20.04 | |
-| IKS 1.27 | Ubuntu 20.04 | |
-| IKS 1.26 | Ubuntu 20.04 | |
-| IKS 1.25 | Ubuntu 20.04 | |
-| IKS 1.24 | Ubuntu 20.04 | |
+| ROKS 4.16 | RHEL 8.9 | :heavy_check_mark: |
+| IKS 1.30 | Ubuntu 20.04 | :heavy_check_mark: |
 
-## Package Dependencies
+## Changelog + Package Dependencies:
 
-| Mount Helper Container Version | Dependencies |
-|------|-------|
-| 1.0.0 | mount-helper-1.0.0 |
+| Mount Helper Container Version | Dependencies | Release | Date | Changes |
+|------|-------|--------|--------|--------|
+| 0.0.2 | mount.ibmshare-0.0.3 | v0.0.5 | April 05, 2024 | - Initial production release |
 
 ## Package Building
 
@@ -35,7 +28,7 @@ This is a REST based mount-helper-container service which is used for mounting E
 
 1. Build rpm based packages use `make rpm-build`
 2. Copy the package on the host system it is required.
-3. Run `yum install -y mount-helper-container-x.y.z.rpm`. This will install all required files.
+3. Run `yum install -y mount-helper-container-x.y.z.rpm --nogpgcheck`. This will install all required files.
 
 The packages will be created inside **/mount-helper-container** folder
 

--- a/mount-helper-container/client/client.go
+++ b/mount-helper-container/client/client.go
@@ -30,7 +30,7 @@ func main() {
 	// socket path
 	socketPath := "/tmp/mysocket.sock"
 	// payload
-	payload := fmt.Sprintf(`{"stagingTargetPath":"fs1235","targetPath":"/test","fsType":"ext4","requestID":"1321"}`)
+	payload := fmt.Sprintf(`{"mountPath":"fs1235","targetPath":"/test","fsType":"ext4","requestID":"1321"}`)
 	// url
 	url := "http://unix/api/mount"
 

--- a/mount-helper-container/server/server_test.go
+++ b/mount-helper-container/server/server_test.go
@@ -58,7 +58,7 @@ func TestHandleMounting(t *testing.T) {
 
 	// Positive Test Case
 	t.Run("Valid Request", func(t *testing.T) {
-		jsonBody := `{"stagingTargetPath": "/staging", "targetPath": "/target", "fsType": "ibmshare", "requestID": "123"}`
+		jsonBody := `{"mountPath": "/source", "targetPath": "/target", "fsType": "ibmshare", "requestID": "123"}`
 		req, err := http.NewRequest("POST", "/api/mount", strings.NewReader(jsonBody))
 		assert.NoError(t, err)
 
@@ -91,7 +91,7 @@ func TestHandleMounting(t *testing.T) {
 			return "", errors.New("mounting failed")
 		}
 
-		jsonBody := `{"stagingTargetPath": "/staging", "targetPath": "/target", "fsType": "ibmshare", "requestID": "123"}`
+		jsonBody := `{"mountPath": "/source", "targetPath": "/target", "fsType": "ibmshare", "requestID": "123"}`
 		req, err := http.NewRequest("POST", "/api/mount", strings.NewReader(jsonBody))
 		assert.NoError(t, err)
 

--- a/mount-helper/Makefile
+++ b/mount-helper/Makefile
@@ -1,7 +1,7 @@
 # Makefile to build deb and rpm packages to install mount.ibmshare on target Linux machines.
 
 NAME := mount.ibmshare
-APP_VERSION := 0.0.2
+APP_VERSION := 0.0.3
 MAINTAINER := "Genctl Share"
 DESCRIPTION := "IBM Mount Share helper"
 LICENSE := "IBM"


### PR DESCRIPTION
The PR contains the following,

- [x] With new changes merged to main for MH in #7 , incremented the mount helper version in makefile to `0.0.3`
- [x] Follow same versioning in mount helper container, set the version to `0.0.2`
- [x] Fixed bug in mount-helper-container Makefile to require particular version of mount-helper in rpm build
- [x] Add mount output as part of API response in mount-helper-container
- [x] Update name of `stagingTargetPath` to `mountPath`
- [x] ~increment version tag in workflow (v0.0.5)~

-------------

TODO:
1. Decide how certs will be delivered from IKS use case -- Will be addressed via #10 
2. Fix MH UTs -- Will be addressed via #10 
3. Rebase this PR