### PR TITLE
Option to use Pre-Prod certs for IKS use case

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - workflow
 
 jobs:
   release:

--- a/mount-helper/Makefile
+++ b/mount-helper/Makefile
@@ -98,7 +98,9 @@ clean:
 	rm -f ./install/*.rpm
 	rm -f ./install/*.deb
 	rm -rf ./install/certs
+	rm -rf ./install/dev_certs
 	mkdir ./install/certs
+	mkdir ./install/dev_certs
 	rm -f ./install/*_*.sh
 	rm -rf *.gz
 
@@ -116,6 +118,7 @@ _dev:
 
 _prod:
 	cp -r ./certs/prod/* ./install/certs
+	cp -r ./certs/dev/* ./install/dev_certs
 	python3 $(PYTHON_MERGE_SCRIPT) ./src "GENERATE_CONFIG"
 	sed -i "s/region=/region=all/" ./install/share.conf
 	sed -i -e '$$a\\ncertificate_duration_seconds=3600' ./install/share.conf

--- a/mount-helper/install/install.sh
+++ b/mount-helper/install/install.sh
@@ -250,6 +250,13 @@ init_mount_helper () {
         sed -i "s/region=.*/$INSTALL_ARG/" ./share.conf
         INSTALL_ARG=""
     fi
+    if [ "$INSTALL_ARG" == "stage" ]; then
+        CERT_PATH="./dev_certs/metadata"
+        log "Installing certs for stage environment..."
+        $SBIN_SCRIPT -INSTALL_ROOT_CERT $CERT_PATH
+        check_result "Problem installing ssl certs"
+        exit_ok "Install completed ok"
+    fi
 
     if [ "$INSTALL_ARG" == "" ]; then
         INSTALL_ARG="metadata"

--- a/mount-helper/test/run_test.sh
+++ b/mount-helper/test/run_test.sh
@@ -5,6 +5,8 @@ export PYTHONPATH=../src:$PYTHONPATH
 rm -f -r ../src./__pycache__
 rm -f -r __pycache__
 
+mkdir -p /opt/ibm/mount-ibmshare
+
 if [[ "$1" == "" ]]; then
     python3 -m unittest discover -f -v -s . -p '*_test.py'
 else


### PR DESCRIPTION
These changes enable IKS team to install Pre-prod certs using input parameters in install.sh script.

If install.sh is ran with an input parameter of "stage", the pre-prod certs will be installed along with the Prod certs.