### PR TITLE
install.sh updates only specific packages installed by mount helper and create a new mount helper release.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,8 +82,8 @@ jobs:
           /home/runner/work/vpc-file-storage-mount-helper/vpc-file-storage-mount-helper/${{ matrix.package_dir }}/mount.ibmshare-latest.tar.gz.sha256
           /home/runner/work/vpc-file-storage-mount-helper/vpc-file-storage-mount-helper/mount-helper-container/mount-helper-container-latest.tar.gz
           /home/runner/work/vpc-file-storage-mount-helper/vpc-file-storage-mount-helper/mount-helper-container/mount-helper-container-latest.tar.gz.sha256
-        tag_name: 0.0.4
-        name: 0.0.4
+        tag_name: 0.0.5
+        name: 0.0.5
         body: CSR generated with SHA1 is not supported to get certs using Metadata.
 
     - name: Initialize CodeQL

--- a/mount-helper/install/install.sh
+++ b/mount-helper/install/install.sh
@@ -167,17 +167,19 @@ _install_app() {
     log "Installing package $PACKAGE_NAME"
     eval "$LINUX_INSTALL_APP $PACKAGE_NAME"
     check_result "Problem installing package: $PACKAGE_NAME"
+    log "Updating package $PACKAGE_NAME"
+    # Update the package 
+    if [ "$LINUX_INSTALL_APP" == "$YUM" ]; then
+        eval "yum update -y $PACKAGE_NAME"
+    elif [ "$LINUX_INSTALL_APP" == "$APT" ]; then
+        eval "apt-get install --only-upgrade -y $PACKAGE_NAME"
+    elif [ "$LINUX_INSTALL_APP" == "$ZYP" ]; then
+        eval "zypper update -y $PACKAGE_NAME"
+    fi
 }
 
 _install_apps() { 
     apps=($@)
-    if [ "$LINUX_INSTALL_APP" == "$YUM" ]; then
-        eval "yum update -y"
-    elif [ "$LINUX_INSTALL_APP" == "$APT" ]; then
-        eval "apt-get update -y"
-    elif [ "$LINUX_INSTALL_APP" == "$ZYP" ]; then
-        eval "zypper update -y"
-    fi
     for app in "${apps[@]}"; do
         if grep -q -i "strongswan" <<< "$app"; then
             check_available_version "$app" $MIN_STRONGSWAN_VERSION


### PR DESCRIPTION
Instead of updating all the packages, install.sh script will update only the packages that are being installed by the install script.