### PR TITLE
Add update option to mount helper

### DIFF
--- a/mount-helper/install/uninstall.sh
+++ b/mount-helper/install/uninstall.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-${0%/*}/install.sh UNINSTALL
+${0%/*}/install.sh --uninstall


### PR DESCRIPTION
There are 2 scenarios we have covered :

Scenario1:  In case any of the certificate(s) are missing/ expired and we fix it in a new release . 
Solution : new release can be downloaded using curl -LO followed by execution of ./install.sh ( no need to uninstall and then install )

Scenario2:  In case the install.sh code is updated and we fix it in a new release.
Solution : new release can be downloaded using curl -LO followed by execution of ./install.sh ( no need to uninstall and then install )

For Scenarios 1 and 2 we ll add -update option to ./install.sh so that it does not tries to install already installed core packages and skips over them. 