### PR TITLE
Mount-helper-container 0.0.4

### DIFF
--- a/mount-helper-container/Makefile
+++ b/mount-helper-container/Makefile
@@ -18,7 +18,7 @@ export LINT_VERSION="1.43.0"
 GOPACKAGES=$(shell go list ./... | grep -v /vendor/ | grep -v /tests)
 
 NAME := mount-helper-container
-APP_VERSION := 0.0.3
+APP_VERSION := 0.0.4
 MAINTAINER := "IKS Storage"
 DESCRIPTION := "IBM Mount-helper-container service"
 LICENSE := "IBM"
@@ -51,7 +51,7 @@ deb-build: build-linux
 	echo "Maintainer: $(MAINTAINER)" >> $(DEBIAN_CONTROL)
 	echo "Architecture: $(DEB_ARCH)" >> $(DEBIAN_CONTROL)
 	echo "Description: $(DESCRIPTION)" >> $(DEBIAN_CONTROL)
-	echo "Depends: mount.ibmshare-0.0.4" >> $(DEBIAN_CONTROL)
+	echo "Depends: mount.ibmshare-0.0.5" >> $(DEBIAN_CONTROL)
 
 	dpkg-deb --build $(BUILD_DIR)
 	rm -rf $(BUILD_DIR)
@@ -71,7 +71,7 @@ rpm-build: build-linux
 	echo "Summary: $(DESCRIPTION)" >> $(REDHAT_SPEC)
 	echo "License: $(LICENSE)" >>  $(REDHAT_SPEC)
 	echo "BuildArch: $(RPM_ARCH)" >>  $(REDHAT_SPEC)
-	echo "Requires: mount.ibmshare = 0.0.4" >> $(REDHAT_SPEC)
+	echo "Requires: mount.ibmshare = 0.0.5" >> $(REDHAT_SPEC)
 	echo "%define _rpmfilename $(NAME)-$(APP_VERSION).rpm" >> $(REDHAT_SPEC)
 	echo "%build" >> $(REDHAT_SPEC)
 

--- a/mount-helper-container/README.md
+++ b/mount-helper-container/README.md
@@ -15,6 +15,7 @@ This is a REST based mount-helper-container service which is used for mounting E
 |------|-------|--------|--------|--------|
 | 0.0.2 | mount.ibmshare-0.0.3 | v0.0.5 | April 05, 2024 | - Initial production release |
 | 0.0.3 | mount.ibmshare-0.0.4 | v0.0.6 | May 24, 2024 | - Changed UNIX socket path |
+| 0.0.4 | mount.ibmshare-0.0.5 | v0.0.8 | Aug 16, 2024 | - Changed mount.ibmshare dep to 0.0.5 (VSI reboot fix, MH update handling, RHEL 8.10 packages added) |
 
 ## Package Building
 


### PR DESCRIPTION
Changes:

- Bumped up MHC version to 0.0.4 
   - Will use new mount.ibmshare package 0.0.5 as dependency
