### PR TITLE
Update actions runner image from Ubuntu 20.04 to 24.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     permissions: write-all 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:


### PR DESCRIPTION
Update actions runner image from Ubuntu 20.04 to 24.04
Signed-off-by: Sai Charan Sunkara <Sai.Charan.Sunkara@ibm.com>