### PR TITLE
MHC support for RHEL 9.5 - Releasing 0.2.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,10 +82,10 @@ jobs:
           /home/runner/work/vpc-file-storage-mount-helper/vpc-file-storage-mount-helper/${{ matrix.package_dir }}/mount.ibmshare-latest.tar.gz.sha256
           /home/runner/work/vpc-file-storage-mount-helper/vpc-file-storage-mount-helper/mount-helper-container/mount-helper-container-latest.tar.gz
           /home/runner/work/vpc-file-storage-mount-helper/vpc-file-storage-mount-helper/mount-helper-container/mount-helper-container-latest.tar.gz.sha256
-        tag_name: 0.2.1
-        name: 0.2.1
+        tag_name: 0.2.2
+        name: 0.2.2
         body: |
-          - Fixed bug in deb control file of mount-helper-container
+          - Added offline packages support for RHEL 9.5
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/mount-helper-container/Makefile
+++ b/mount-helper-container/Makefile
@@ -18,7 +18,7 @@ export LINT_VERSION="1.43.0"
 GOPACKAGES=$(shell go list ./... | grep -v /vendor/ | grep -v /tests)
 
 NAME := mount-helper-container
-APP_VERSION := 0.1.2
+APP_VERSION := 0.1.3
 MAINTAINER := "IKS Storage"
 DESCRIPTION := "IBM Mount-helper-container service"
 LICENSE := "IBM"
@@ -51,7 +51,7 @@ deb-build: build-linux
 	echo "Maintainer: $(MAINTAINER)" >> $(DEBIAN_CONTROL)
 	echo "Architecture: $(DEB_ARCH)" >> $(DEBIAN_CONTROL)
 	echo "Description: $(DESCRIPTION)" >> $(DEBIAN_CONTROL)
-	echo "Depends: mount.ibmshare (= 0.1.7)" >> $(DEBIAN_CONTROL)
+	echo "Depends: mount.ibmshare (= 0.1.8)" >> $(DEBIAN_CONTROL)
 
 	dpkg-deb --build $(BUILD_DIR)
 	rm -rf $(BUILD_DIR)
@@ -71,7 +71,7 @@ rpm-build: build-linux
 	echo "Summary: $(DESCRIPTION)" >> $(REDHAT_SPEC)
 	echo "License: $(LICENSE)" >>  $(REDHAT_SPEC)
 	echo "BuildArch: $(RPM_ARCH)" >>  $(REDHAT_SPEC)
-	echo "Requires: mount.ibmshare = 0.1.7" >> $(REDHAT_SPEC)
+	echo "Requires: mount.ibmshare = 0.1.8" >> $(REDHAT_SPEC)
 	echo "%define _rpmfilename $(NAME)-$(APP_VERSION).rpm" >> $(REDHAT_SPEC)
 	echo "%build" >> $(REDHAT_SPEC)
 

--- a/mount-helper-container/README.md
+++ b/mount-helper-container/README.md
@@ -24,6 +24,7 @@ This is a REST based mount-helper-container service which is used for mounting E
 | 0.1.0 | mount.ibmshare-0.1.1 | v0.1.4 | March 9, 2025 | - Changed mount.ibmshare dep to 0.1.0 (Add Cert for Montreal Prod) |
 | 0.1.1 | mount.ibmshare-0.1.7 | v0.2.0 | July 30, 2025 | - Changed mount.ibmshare dep to 0.1.0 (Add Support fo RHEL 9.6 + Mh misc changes https://github.com/IBM/vpc-file-storage-mount-helper/compare/0.1.4...0.1.9) |
 | 0.1.2 | mount.ibmshare-0.1.7 | v0.2.1 | August 5, 2025 | - Fixed bug in deb control file |
+| 0.1.3 | mount.ibmshare-0.1.8 | v0.2.2 | Sep 1, 2025 | - Add offline packages support for RHEL 9.5 |
 
 ## Package Building
 

--- a/mount-helper/Makefile
+++ b/mount-helper/Makefile
@@ -1,7 +1,7 @@
 # Makefile to build deb and rpm packages to install mount.ibmshare on target Linux machines.
 
 NAME := mount.ibmshare
-APP_VERSION := 0.1.7
+APP_VERSION := 0.1.8
 MAINTAINER := "Genctl Share"
 DESCRIPTION := "IBM Mount Share helper"
 LICENSE := "IBM"


### PR DESCRIPTION
**Note:** To be merged only after https://github.com/IBM/vpc-file-storage-mount-helper/pull/76 is merged