### PR TITLE
Support for PPC VSI without ipsec dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,10 +82,11 @@ jobs:
           /home/runner/work/vpc-file-storage-mount-helper/vpc-file-storage-mount-helper/${{ matrix.package_dir }}/mount.ibmshare-latest.tar.gz.sha256
           /home/runner/work/vpc-file-storage-mount-helper/vpc-file-storage-mount-helper/mount-helper-container/mount-helper-container-latest.tar.gz
           /home/runner/work/vpc-file-storage-mount-helper/vpc-file-storage-mount-helper/mount-helper-container/mount-helper-container-latest.tar.gz.sha256
-        tag_name: 0.2.2
-        name: 0.2.2
+        tag_name: 0.2.3
+        name: 0.2.3
         body: |
           - Added offline packages support for RHEL 9.5
+          - Supporting PPC for RHEL 9.4
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/mount-helper/install/install_stunnel.sh
+++ b/mount-helper/install/install_stunnel.sh
@@ -56,6 +56,7 @@ local stunnel_env="STUNNEL_ENV"
 
     # It is okay to store empty value.
     local value="$STUNNEL_ENV"
+
     sed -i.bak "/${stunnel_env}=/d"  "$CONF_FILE"
 
     if  ! grep -q $stunnel_env $CONF_FILE
@@ -77,8 +78,9 @@ local root_ca="TRUSTED_ROOT_CACERT"
 
 # Create necessary directories
 setup_stunnel_directories() {
-    sudo mkdir -p /var/run/stunnel4/ /etc/stunnel /var/log/stunnel
-    sudo chmod 744 /var/run/stunnel4/ /etc/stunnel /var/log/stunnel
+    DIR_LIST="/var/run/stunnel4/ /etc/stunnel /var/log/stunnel"
+    sudo mkdir -p $DIR_LIST
+    sudo chmod 744 $DIR_LIST
 }
 
 # Install stunnel on Ubuntu/Debian-based systems
@@ -92,6 +94,7 @@ install_stunnel_ubuntu_debian() {
 
     store_trusted_ca_file_name "/etc/ssl/certs/ca-certificates.crt"
     store_stunnel_env
+    store_arch_env
     # Verify installation
     if command -v stunnel > /dev/null; then
         echo "stunnel installed successfully!"
@@ -101,11 +104,22 @@ install_stunnel_ubuntu_debian() {
     fi
 }
 
+store_arch_env() {
+    local arch_env="ARCH_ENV"
+
+    local value="$(uname -m)"
+
+    sed -i.bak "/${arch_env}=/d"  "$CONF_FILE"
+
+    if  ! grep -q $arch_env $CONF_FILE
+    then
+        echo ${arch_env}="$value" >> $CONF_FILE
+    fi
+}
+
 # Install stunnel on Red Hat/CentOS/Rocky-based systems
 install_stunnel_rhel_centos_rocky() {
     echo "Starting installation of stunnel on Red Hat/CentOS/Rocky-based system..."
-    # Install EPEL repository if not already installed
-    sudo yum install -y epel-release
 
     # Install stunnel
     sudo yum install -y stunnel
@@ -114,6 +128,7 @@ install_stunnel_rhel_centos_rocky() {
 
     store_trusted_ca_file_name "/etc/pki/tls/certs/ca-bundle.crt"
     store_stunnel_env
+    store_arch_env
 
     # Verify installation
     if command -v stunnel > /dev/null; then

--- a/mount-helper/src/stunnel_config_create.py
+++ b/mount-helper/src/stunnel_config_create.py
@@ -29,10 +29,10 @@ class StunnelConfigCreate:
 
     def get_stunnel_env(
         self,
-        conf_file_name=StunnelConfigGet.CONFIG_FILE_NAME,
+        conf_file_name=StunnelConfigGet.SHARE_CONFIG_FILE,
         key_name=StunnelConfigGet.STUNNEL_ENV_KEY,
     ):
-        value = self.get_from_config_file(conf_file_name, key_name)
+        value = self.get_from_ibmshare_config(conf_file_name, key_name)
         if value is not None:
             value = value.lower()
 
@@ -49,13 +49,13 @@ class StunnelConfigCreate:
 
     def get_trusted_ca_file(
         self,
-        conf_file_name=StunnelConfigGet.CONFIG_FILE_NAME,
+        conf_file_name=StunnelConfigGet.SHARE_CONFIG_FILE,
         key_name=StunnelConfigGet.CA_FILE_KEY,
     ):
-        return self.get_from_config_file(conf_file_name, key_name)
+        return self.get_from_ibmshare_config(conf_file_name, key_name)
 
     # Extract the value from the key value in conf file.
-    def get_from_config_file(self, conf_file_name, key_name):
+    def get_from_ibmshare_config(self, conf_file_name, key_name):
         value = None
         self.valid = True
         try:

--- a/mount-helper/src/stunnel_config_get.py
+++ b/mount-helper/src/stunnel_config_get.py
@@ -15,7 +15,7 @@ class StunnelConfigGet:
     STUNNEL_LOG_DIR = "/var/log/stunnel"
     STUNNEL_CONF_EXT = ".conf"
     STUNNEL_IDENTIFIER = "stunnel_identifier"
-    CONFIG_FILE_NAME = "/etc/ibmcloud/share.conf"
+    SHARE_CONFIG_FILE = "/etc/ibmcloud/share.conf"
     CA_FILE_KEY = "TRUSTED_ROOT_CACERT"
     STUNNEL_ENV_KEY = "STUNNEL_ENV"
 

--- a/mount-helper/test/mount_ibmshare_test.py
+++ b/mount-helper/test/mount_ibmshare_test.py
@@ -154,6 +154,14 @@ class TestMountIbmshare(unittest.TestCase):
         self.assertFalse(ret)
         self.assertEqual(o.ipsec.create_config.call_count, 1)
 
+    def test_ipsec_not_allowed_on_ppc(self, ocert):
+        mo = mount_ibmshare.MountIbmshare()
+        mo.is_ppc= MagicMock(return_value = True)
+        args = ArgsHandler.get_mount_args()
+        args.is_secure = True
+        ret = mo.mount(args)
+        self.assertFalse(ret)
+
     @mock.patch("os.path.isdir")
     def test_set_installed_stunnel(self, is_dir_handle, ignore_ocert):
         is_dir_handle.return_value = False

--- a/mount-helper/test/stunnel_config_create_test.py
+++ b/mount-helper/test/stunnel_config_create_test.py
@@ -122,7 +122,7 @@ class TestStunnelConfigCreate(unittest.TestCase):
         self.assertEqual(s.is_valid(), False)
 
     def run_get_stunnel_env_test(self, stunnel_obj, magic_method, expected_return):
-        stunnel_obj.get_from_config_file = magic_method
+        stunnel_obj.get_from_ibmshare_config = magic_method
         ret = stunnel_obj.get_stunnel_env()
         self.assertEqual(ret, expected_return)
 


### PR DESCRIPTION
Stunnel piggybacked on IPsec base code. This meant that ipsec was also installed along with Stunnel.
Ipsec packages are no longer installed on PPC based VSI.
Stunnel has been tested successfully on PPC.