### PR TITLE
fix: AP-15315: RHCOS Stunnel Mount fix post installation

### DIFF
--- a/mount-helper/install/install_stunnel.sh
+++ b/mount-helper/install/install_stunnel.sh
@@ -5,21 +5,24 @@ INSTALL="install"
 UNINSTALL="uninstall"
 CONF_FILE=/etc/ibmshare/share.conf
 
-if [ ! -f "$CONF_FILE" ]; then
-    echo ""
-    echo "ERROR: share.conf not found."
-    echo "Mount helper not initialized yet."
-    echo ""
-    echo "If this is first install on RHCOS:"
-    echo "  1. Reboot node"
-    echo "  2. Run install.sh --stunnel again"
-    echo ""
-    exit 1
-fi
-
 # Base path: packages folder sits next to this script
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 PACKAGES_BASE="${SCRIPT_DIR}/packages"
+
+ACTION="$(echo "${1:-$INSTALL}" | tr '[:upper:]' '[:lower:]')"
+
+if [[ "$ACTION" == "$INSTALL" && ! -f "$CONF_FILE" ]]; then
+    mkdir -p /etc/ibmshare
+    cp "$SCRIPT_DIR/share.conf" "$CONF_FILE"
+    echo "Default share.conf initialized at $CONF_FILE"
+fi
+
+if [[ "$ACTION" == "$UNINSTALL" ]]; then
+    if [ -f "$CONF_FILE" ]; then
+        rm -f "$CONF_FILE"
+        echo "Removed $CONF_FILE"
+    fi
+fi
 
 # Temporary: Add a test certificate to /etc/stunnel if stunnel is installed
 # This is a non-production test certificate used only during development.
@@ -69,17 +72,44 @@ EOF
 
 setup_stunnel_directories() {
     local DIR_LIST="/var/run/stunnel4/ /etc/stunnel /var/log/stunnel"
-    $SUDO mkdir -p $DIR_LIST
-    $SUDO chmod 744 $DIR_LIST
+    sudo mkdir -p $DIR_LIST
+    sudo chmod 744 $DIR_LIST
+}
+
+setup_stunnel_directories_rhcos() {
+    local DIR_LIST="/var/run/stunnel4/ /etc/stunnel /var/log/stunnel"
+    mkdir -p $DIR_LIST
+    chmod 744 $DIR_LIST
 }
 
 store_kv() {
     local k="$1"
     local v="$2"
-    $SUDO mkdir -p "$(dirname "$CONF_FILE")"
-    $SUDO touch "$CONF_FILE"
-    $SUDO sed -i.bak "/^${k}=*/d" "$CONF_FILE"
-    echo "${k}=${v}" | $SUDO tee -a "$CONF_FILE" >/dev/null
+    sudo mkdir -p "$(dirname "$CONF_FILE")"
+    sudo touch "$CONF_FILE"
+    sudo sed -i.bak "/^${k}=*/d" "$CONF_FILE"
+    echo "${k}=${v}" | sudo tee -a "$CONF_FILE" >/dev/null
+}
+
+store_kv_rhcos() {
+    local k="$1"
+    local v="$2"
+    mkdir -p "$(dirname "$CONF_FILE")"
+    touch "$CONF_FILE"
+    sed -i.bak "/^${k}=*/d" "$CONF_FILE"
+    echo "${k}=${v}" | tee -a "$CONF_FILE" >/dev/null
+}
+
+store_stunnel_env_rhcos() {
+    store_kv_rhcos STUNNEL_ENV "${STUNNEL_ENV:-}"
+}
+
+store_trusted_ca_file_name_rhcos() {
+    store_kv_rhcos TRUSTED_ROOT_CACERT "$*"
+}
+
+store_arch_env_rhcos() {
+    store_kv_rhcos ARCH_ENV "$(uname -m)"
 }
 
 store_stunnel_env() {
@@ -183,24 +213,21 @@ install_stunnel_rhcos() {
     echo "RHCOS offline-first installation path selected"
     echo "Offline stunnel install (RHCOS)…"
 
-    #
-    # Runtime phase (after reboot)
-    #
-    if rpm -q stunnel >/dev/null 2>&1; then
-        echo "stunnel already installed. Running runtime configuration..."
-
-        setup_stunnel_directories
-        create_stunnel_cert_if_installed
-        store_trusted_ca_file_name "/etc/pki/tls/certs/ca-bundle.crt"
-        store_stunnel_env
-        store_arch_env
-
-        echo "Runtime configuration completed."
-        return 0
+    if ! grep -q TRUSTED_ROOT_CACERT "$CONF_FILE"; then
+        store_trusted_ca_file_name_rhcos "/etc/pki/tls/certs/ca-bundle.crt"
     fi
 
     #
-    # Install phase (first run)
+    # Execute runtime configuration
+    #
+    setup_stunnel_directories_rhcos
+    create_stunnel_cert_if_installed
+    store_trusted_ca_file_name_rhcos "/etc/pki/tls/certs/ca-bundle.crt"
+    store_stunnel_env_rhcos
+    store_arch_env_rhcos
+
+    #
+    # Install stunnel RPM
     #
     STUNNEL_RPM=$(find "${PACKAGES_BASE}/rhel" -type f -name "stunnel*.rpm" | head -1)
 
@@ -220,7 +247,6 @@ install_stunnel_rhcos() {
     echo "=================================================="
     echo "stunnel installation staged successfully."
     echo "Reboot REQUIRED to activate changes."
-    echo "After reboot run: install_stunnel.sh install"
     echo "=================================================="
     echo ""
 }
@@ -274,11 +300,6 @@ else
     OS_TYPE="$ID"
 fi
 
-SUDO="sudo"
-if [[ "$OS_TYPE" == "rhcos" ]]; then
-    SUDO=""
-fi
-
 case "$OS_TYPE" in
     ubuntu|debian)
         if [ "$ACTION" = "$INSTALL" ]; then
@@ -317,7 +338,6 @@ esac
 }
 
 # Default action is install
-ACTION="$(echo "${1:-$INSTALL}" | tr '[:upper:]' '[:lower:]')"
 if [[ "$ACTION" != "$INSTALL" && "$ACTION" != "$UNINSTALL" ]]; then
     echo "Use: install|uninstall"
     exit 1

--- a/mount-helper/install/install_stunnel.sh
+++ b/mount-helper/install/install_stunnel.sh
@@ -16,6 +16,13 @@ if [ ! -f "$CONF_FILE" ]; then
     echo ""
     exit 1
 fi
+
+SUDO="sudo"
+
+if [[ "$OS_TYPE" == "rhcos" ]]; then
+    SUDO=""
+fi
+
 # Base path: packages folder sits next to this script
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 PACKAGES_BASE="${SCRIPT_DIR}/packages"
@@ -68,16 +75,16 @@ EOF
 
 setup_stunnel_directories() {
     local DIR_LIST="/var/run/stunnel4/ /etc/stunnel /var/log/stunnel"
-    sudo mkdir -p $DIR_LIST
-    sudo chmod 744 $DIR_LIST
+    $SUDO mkdir -p $DIR_LIST
+    $SUDO chmod 744 $DIR_LIST
 }
 
 store_kv() {
     local k="$1"
     local v="$2"
-    sudo mkdir -p "$(dirname "$CONF_FILE")"
-    sudo touch "$CONF_FILE"
-    sudo sed -i.bak "/^${k}=*/d" "$CONF_FILE"
+    $SUDO mkdir -p "$(dirname "$CONF_FILE")"
+    $SUDO touch "$CONF_FILE"
+    $SUDO sed -i.bak "/^${k}=*/d" "$CONF_FILE"
     echo "${k}=${v}" | sudo tee -a "$CONF_FILE" >/dev/null
 }
 

--- a/mount-helper/install/install_stunnel.sh
+++ b/mount-helper/install/install_stunnel.sh
@@ -17,12 +17,6 @@ if [ ! -f "$CONF_FILE" ]; then
     exit 1
 fi
 
-SUDO="sudo"
-
-if [[ "$OS_TYPE" == "rhcos" ]]; then
-    SUDO=""
-fi
-
 # Base path: packages folder sits next to this script
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 PACKAGES_BASE="${SCRIPT_DIR}/packages"
@@ -85,7 +79,7 @@ store_kv() {
     $SUDO mkdir -p "$(dirname "$CONF_FILE")"
     $SUDO touch "$CONF_FILE"
     $SUDO sed -i.bak "/^${k}=*/d" "$CONF_FILE"
-    echo "${k}=${v}" | sudo tee -a "$CONF_FILE" >/dev/null
+    echo "${k}=${v}" | $SUDO tee -a "$CONF_FILE" >/dev/null
 }
 
 store_stunnel_env() {
@@ -226,6 +220,7 @@ install_stunnel_rhcos() {
     echo "=================================================="
     echo "stunnel installation staged successfully."
     echo "Reboot REQUIRED to activate changes."
+    echo "After reboot run: install_stunnel.sh install"
     echo "=================================================="
     echo ""
 }
@@ -277,6 +272,11 @@ if [[ "$ID" == "rhcos" ]] || [[ "${VARIANT_ID:-}" == *"coreos"* ]]; then
     OS_TYPE="rhcos"
 else
     OS_TYPE="$ID"
+fi
+
+SUDO="sudo"
+if [[ "$OS_TYPE" == "rhcos" ]]; then
+    SUDO=""
 fi
 
 case "$OS_TYPE" in

--- a/mount-helper/install/install_stunnel.sh
+++ b/mount-helper/install/install_stunnel.sh
@@ -184,6 +184,52 @@ install_stunnel_suse() {
     fi
 }
 
+install_stunnel_rhcos() {
+
+    echo "RHCOS offline-first installation path selected"
+    echo "Offline stunnel install (RHCOS)…"
+
+    #
+    # Runtime phase (after reboot)
+    #
+    if rpm -q stunnel >/dev/null 2>&1; then
+        echo "stunnel already installed. Running runtime configuration..."
+
+        setup_stunnel_directories
+        create_stunnel_cert_if_installed
+        store_trusted_ca_file_name "/etc/pki/tls/certs/ca-bundle.crt"
+        store_stunnel_env
+        store_arch_env
+
+        echo "Runtime configuration completed."
+        return 0
+    fi
+
+    #
+    # Install phase (first run)
+    #
+    STUNNEL_RPM=$(find "${PACKAGES_BASE}/rhel" -type f -name "stunnel*.rpm" | head -1)
+
+    if [ -z "$STUNNEL_RPM" ]; then
+        echo ""
+        echo "ERROR: stunnel RPM not found."
+        echo "Offline installation required for RHCOS."
+        exit 1
+    fi
+
+    echo "Installing stunnel from offline RPM:"
+    echo "  $STUNNEL_RPM"
+
+    rpm-ostree install -y --idempotent "$STUNNEL_RPM"
+
+    echo ""
+    echo "=================================================="
+    echo "stunnel installation staged successfully."
+    echo "Reboot REQUIRED to activate changes."
+    echo "=================================================="
+    echo ""
+}
+
 # Uninstall stunnel on Ubuntu/Debian-based systems
 uninstall_stunnel_ubuntu_debian() {
   echo "Uninstalling stunnel (Ubuntu/Debian)…"
@@ -250,53 +296,10 @@ case "$OS_TYPE" in
         ;;
     rhcos)
         if [ "$ACTION" = "$INSTALL" ]; then
-            echo "RHCOS offline-first installation path selected"
-
-            #
-            # -------------------------------------------------
-            # Runtime phase (after reboot)
-            # -------------------------------------------------
-            #
-            if rpm -q stunnel >/dev/null 2>&1; then
-                echo "stunnel already installed. Running runtime configuration..."
-
-                setup_stunnel_directories
-                create_stunnel_cert_if_installed
-                store_trusted_ca_file_name "/etc/pki/tls/certs/ca-bundle.crt"
-                store_stunnel_env
-                store_arch_env
-
-                echo "Runtime configuration completed."
-                exit 0
-            fi
-
-            #
-            # -------------------------------------------------
-            # Install phase (first run)
-            # -------------------------------------------------
-            #
-            STUNNEL_RPM=$(find "${PACKAGES_BASE}/rhel" -type f -name "stunnel*.rpm" | head -1)
-
-            if [ -z "$STUNNEL_RPM" ]; then
-                echo ""
-                echo "ERROR: stunnel RPM not found."
-                echo "Offline installation required for RHCOS."
-                exit 1
-            fi
-
-            echo "Installing stunnel from offline RPM:"
-            echo "  $STUNNEL_RPM"
-
-            rpm-ostree install -y --idempotent "$STUNNEL_RPM"
-
-            echo ""
-            echo "=================================================="
-            echo "stunnel installation staged successfully."
-            echo "Reboot REQUIRED to activate changes."
-            echo "=================================================="
-            echo ""
-
-            exit 0
+            install_stunnel_rhcos
+        else
+            echo "Uninstalling stunnel on RHCOS..."
+            rpm-ostree uninstall stunnel || true
         fi
         ;;
     suse|sles)


### PR DESCRIPTION
Ticket - https://ibm-iaas.atlassian.net/browse/AP-15315

Changes - 
1. sudo does not work in RHCOS so refactored the code
2. defining function for install_stunnel_rhcos

Evidence - 

1. share.conf is present 
2. TRUSTED_ROOT_CACERT also generated. 

<img width="1079" height="761" alt="image" src="https://github.com/user-attachments/assets/e7ae5488-e1f6-4cd0-b8bf-703d93afdca7" />
