### PR TITLE
MHC: Update socker path

### DIFF
--- a/mount-helper-container/server/server.go
+++ b/mount-helper-container/server/server.go
@@ -40,7 +40,7 @@ func init() {
 
 var (
 	logger     *zap.Logger
-	socketDir  = "/var/lib/"
+	socketDir  = "/run/ibm-vpc-file-csi/"
 	socketPath = socketDir + "ibmshare.sock"
 )
 


### PR DESCRIPTION
In RHCOS, we already mount /var/data dir, which shares same iNode as /var/li. This causes driver to return "device or resource busy" because another reference to same mount still exists through overlapping namespace propagation.

Changing it to /run dir so that the issue doesnot arise