### PR TITLE
MH: Fix Installation issue on older version of CoreOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,14 +84,10 @@ jobs:
           /home/runner/work/vpc-file-storage-mount-helper/vpc-file-storage-mount-helper/${{ matrix.package_dir }}/mount.ibmshare-latest.tar.gz.sha256
           /home/runner/work/vpc-file-storage-mount-helper/vpc-file-storage-mount-helper/mount-helper-container/mount-helper-container-latest.tar.gz
           /home/runner/work/vpc-file-storage-mount-helper/vpc-file-storage-mount-helper/mount-helper-container/mount-helper-container-latest.tar.gz.sha256
-        tag_name: 0.2.5
-        name: 0.2.5
+        tag_name: 0.2.6
+        name: 0.2.6
         body: |
-          - Conf changes to enable quick ipsec mounts recovery during backend upgrade
-          - Added offline packages support for RHEL 9.5
-          - Supporting PPC for RHEL 9.4
-          - Added the root and int certs for CHE 
-          - Add support for stunnel
+          - Fixed CoreOS package version detection for older releases in mount-helper install script.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
 

--- a/mount-helper/Makefile
+++ b/mount-helper/Makefile
@@ -1,7 +1,7 @@
 # Makefile to build deb and rpm packages to install mount.ibmshare on target Linux machines.
 
 NAME := mount.ibmshare
-APP_VERSION := 0.1.9
+APP_VERSION := 0.1.10
 MAINTAINER := "Genctl Share"
 DESCRIPTION := "IBM Mount Share helper"
 LICENSE := "IBM"

--- a/mount-helper/install/install.sh
+++ b/mount-helper/install/install.sh
@@ -24,10 +24,6 @@ LINUX_INSTALL_APP=""
 INSTALL_APP="Unknown"
 NAME=$(grep -oP '(?<=^NAME=).+' /etc/os-release | tr -d '"')
 VERSION=$(grep -oP '(?<=^VERSION_ID=).+' /etc/os-release | tr -d '"')
-ARCH="$(uname -m)"
-MAJOR_VERSION=${VERSION%.*}
-INSTALLED_PACKAGE_LIST="/etc/pre_installed_packages.txt"
-DOWNLOADED_RHEL_PACKAGE_PATH="packages/rhel/$VERSION"
 
 #              Name              Min Version    Install
 LINUX_UBUNTU=("Ubuntu"           "18"           "$APT")
@@ -38,6 +34,19 @@ LINUX_FEDORA=("Fedora Linux"     $NA            $NA)
 LINUX_SUSE=("SLES"               "12"           "$ZYP")
 LINUX_RED_HAT_COREOS=("Red Hat Enterprise Linux CoreOS" "4" "$OSTREE")
 LINUX_RED_HAT=("Red Hat Enterprise Linux" "7" "$YUM")
+
+# Older RHCOS releases expose OpenShift version in VERSION_ID
+# and actual RHEL version is in RHEL_VERSION.
+RHEL_VERSION_VALUE=$(grep -oP '(?<=^RHEL_VERSION=).+' /etc/os-release | tr -d '"' || true)
+
+if [[ "$NAME" == "${LINUX_RED_HAT_COREOS[0]}" && -n "$RHEL_VERSION_VALUE" ]]; then
+    VERSION="$RHEL_VERSION_VALUE"
+fi
+
+ARCH="$(uname -m)"
+MAJOR_VERSION=${VERSION%.*}
+INSTALLED_PACKAGE_LIST="/etc/pre_installed_packages.txt"
+DOWNLOADED_RHEL_PACKAGE_PATH="packages/rhel/$VERSION"
 
 declare -A region_map=(
     ["dal"]="us-south"


### PR DESCRIPTION
On ROKS RHCOS versions 4.17 and 4.18, the /etc/os-release file exposes the OpenShift version in the VERSION_ID field instead of the actual RHEL version. This causes the installation script to fail because it tries to select packages for a non-existent RHEL version.

Have observed this os-release o/p in RedHat CoreOS


```
### RHCOS 4.17
sh-5.1# cat /etc/os-release
NAME="Red Hat Enterprise Linux CoreOS"
ID="rhcos"
ID_LIKE="rhel fedora"
VERSION="417.94.202603242359-0"
VERSION_ID="4.17"
VARIANT="CoreOS"
VARIANT_ID=coreos
PLATFORM_ID="platform:el9"
PRETTY_NAME="Red Hat Enterprise Linux CoreOS 417.94.202603242359-0"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:redhat:enterprise_linux:9::baseos::coreos"
HOME_URL="https://www.redhat.com/"
DOCUMENTATION_URL="https://docs.okd.io/latest/welcome/index.html"
BUG_REPORT_URL="https://access.redhat.com/labs/rhir/"
REDHAT_BUGZILLA_PRODUCT="OpenShift Container Platform"
REDHAT_BUGZILLA_PRODUCT_VERSION="4.17"
REDHAT_SUPPORT_PRODUCT="OpenShift Container Platform"
REDHAT_SUPPORT_PRODUCT_VERSION="4.17"
OPENSHIFT_VERSION="4.17"
RHEL_VERSION=9.4
OSTREE_VERSION="417.94.202603242359-0"


### RHCOS 4.18
sh-5.1# cat /etc/os-release
NAME="Red Hat Enterprise Linux CoreOS"
ID="rhcos"
ID_LIKE="rhel fedora"
VERSION="418.94.202603261158-0"
VERSION_ID="4.18"
VARIANT="CoreOS"
VARIANT_ID=coreos
PLATFORM_ID="platform:el9"
PRETTY_NAME="Red Hat Enterprise Linux CoreOS 418.94.202603261158-0"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:redhat:enterprise_linux:9::baseos::coreos"
HOME_URL="https://www.redhat.com/"
DOCUMENTATION_URL="https://docs.okd.io/latest/welcome/index.html"
BUG_REPORT_URL="https://access.redhat.com/labs/rhir/"
REDHAT_BUGZILLA_PRODUCT="OpenShift Container Platform"
REDHAT_BUGZILLA_PRODUCT_VERSION="4.18"
REDHAT_SUPPORT_PRODUCT="OpenShift Container Platform"
REDHAT_SUPPORT_PRODUCT_VERSION="4.18"
OPENSHIFT_VERSION="4.18"
RHEL_VERSION=9.4
OSTREE_VERSION="418.94.202603261158-0"

### RHCOS 4.19
sh-5.1# cat /etc/os-release
NAME="Red Hat Enterprise Linux CoreOS"
VERSION="9.6.20260420-0 (Plow)"
ID="rhel"
ID_LIKE="fedora"
VERSION_ID="9.6"
PLATFORM_ID="platform:el9"
PRETTY_NAME="Red Hat Enterprise Linux CoreOS 9.6.20260420-0 (Plow)"
ANSI_COLOR="0;31"
LOGO="fedora-logo-icon"
CPE_NAME="cpe:/o:redhat:enterprise_linux:9::baseos"
HOME_URL="https://www.redhat.com/"
DOCUMENTATION_URL="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9"
BUG_REPORT_URL="https://issues.redhat.com/"
REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 9"
REDHAT_BUGZILLA_PRODUCT_VERSION=9.6
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="9.6"
OSTREE_VERSION='9.6.20260420-0'
VARIANT=CoreOS
VARIANT_ID=coreos
OPENSHIFT_VERSION="4.19"

### RHCOS 4.20
sh-5.1# cat /etc/os-release
NAME="Red Hat Enterprise Linux CoreOS"
VERSION="9.6.20260401-0 (Plow)"
ID="rhel"
ID_LIKE="fedora"
VERSION_ID="9.6"
PLATFORM_ID="platform:el9"
PRETTY_NAME="Red Hat Enterprise Linux CoreOS 9.6.20260401-0 (Plow)"
ANSI_COLOR="0;31"
LOGO="fedora-logo-icon"
CPE_NAME="cpe:/o:redhat:enterprise_linux:9::baseos"
HOME_URL="https://www.redhat.com/"
DOCUMENTATION_URL="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9"
BUG_REPORT_URL="https://issues.redhat.com/"
REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 9"
REDHAT_BUGZILLA_PRODUCT_VERSION=9.6
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="9.6"
OSTREE_VERSION='9.6.20260401-0'
VARIANT=CoreOS
VARIANT_ID=coreos
OPENSHIFT_VERSION="4.20"
```

- For versions < 4.18, VERSION_ID shows the openshift version instead of the RHEL version. Because if this existing scripts fail during the installation of packages
- The fix is to override VERSION on older RHCOS systems by using RHEL_VERSION when available.