### PR TITLE
MH: Fix instllation issue during update for RHCOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,11 +84,10 @@ jobs:
           /home/runner/work/vpc-file-storage-mount-helper/vpc-file-storage-mount-helper/${{ matrix.package_dir }}/mount.ibmshare-latest.tar.gz.sha256
           /home/runner/work/vpc-file-storage-mount-helper/vpc-file-storage-mount-helper/mount-helper-container/mount-helper-container-latest.tar.gz
           /home/runner/work/vpc-file-storage-mount-helper/vpc-file-storage-mount-helper/mount-helper-container/mount-helper-container-latest.tar.gz.sha256
-        tag_name: 0.2.6
-        name: 0.2.6
+        tag_name: 0.2.7
+        name: 0.2.7
         body: |
-          - Fixed CoreOS package version detection for older releases in mount-helper install script.
-    - name: Initialize CodeQL
+          - Fixed an issue where the installation of the mount helper package would fail in case of update.
       uses: github/codeql-action/init@v2
 
     - name: Perform CodeQL Analysis Mount Helper Code

--- a/mount-helper/Makefile
+++ b/mount-helper/Makefile
@@ -1,7 +1,7 @@
 # Makefile to build deb and rpm packages to install mount.ibmshare on target Linux machines.
 
 NAME := mount.ibmshare
-APP_VERSION := 0.1.10
+APP_VERSION := 0.1.11
 MAINTAINER := "Genctl Share"
 DESCRIPTION := "IBM Mount Share helper"
 LICENSE := "IBM"

--- a/mount-helper/install/install.sh
+++ b/mount-helper/install/install.sh
@@ -579,11 +579,12 @@ _install_apps() {
             log "Installing package $app"
             if [[ $app == mount.ibmshare* ]]; then
                 if [[ "$INSTALL_ARG" == "--update" || "$INSTALL_ARG" == "--update-stage" ]]; then
-                    rpm-ostree upgrade "$app" 
+                    log "Updating existing package $app"
+                    rpm-ostree uninstall mount.ibmshare --install "$app"
                 else
-                    rpm-ostree install -y --idempotent "$app" 
+                    rpm-ostree install -y --idempotent "$app"
                 fi
-            continue
+                continue
             fi
             if [[ $app == *"python"* ]]; then
                 rpm-ostree install -y --idempotent "$app" 
@@ -1140,6 +1141,12 @@ if is_linux LINUX_RED_HAT_COREOS; then
             while IFS= read -r line; do
                 packages+=("$line")
             done < "$PACKAGE_LIST_PATH"
+
+            # Disable EPEL repos if present - Required for Secure By Default clusters
+            if ls /etc/yum.repos.d/epel*.repo 1>/dev/null 2>&1; then
+                sed -i 's/enabled=1/enabled=0/' /etc/yum.repos.d/epel*.repo
+                log "Disabled EPEL repos for Secure By Default cluster"
+            fi
 
             # Install the packages in the defined order
             install_apps "${packages[@]}" mount.ibmshare*.rpm


### PR DESCRIPTION
The mount.ibmshare package update gets stuck in Secure By Default(SBD) cluster, because of how the command `rpm os-tree upgrade mount.ibshare` works.
 
Error:
```
Using install app: rpm-ostree
Installing package mount.ibmshare-0.1.11.rpm
Pulling manifest: ostree-unverified-registry:quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:cbfd3d0256b95e05653a486cedbe67186c29fbc9a212b46a46918a63b2ff12fd
Checking out tree d650da6... done
Enabled rpm-md repositories: epel-cisco-openh264 epel
⠁ Updating metadata for 'epel-cisco-openh264'   0% [░░░░░░░░░░░░░░░░░░░░] (0s)  %
```

- Attempts full OS upgrade from quay.io
- Refreshes all repos including EPEL -> hangs because internet access is not there
- mount.ibmshare never actually updated

-----------

Fix 1:
- Disable EPEL so that there are no connections made for EPEL refresh

Fix 2:
- Instead of `rpm os-tree upgrade` used `rpm-ostree uninstall mount.ibmshare --install "$app"`
- This will do both operations in a single command
- If we do uninstall and install in 2 commands, it would create 2 depoyments which gives conflict