### PR TITLE
Revert removed line in release yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,7 @@ jobs:
         name: 0.2.7
         body: |
           - Fixed an issue where the installation of the mount helper package would fail in case of update.
+    - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
 
     - name: Perform CodeQL Analysis Mount Helper Code


### PR DESCRIPTION
In previous PR, by mistake removed one line and got merged https://github.com/IBM/vpc-file-storage-mount-helper/pull/114/changes#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34, which is causing issue durting github actions.

Reverted it back