### PR TITLE
MHC: Fix uninstall issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - main
+      - mhc-rpm-fix
 
 jobs:
   release:
@@ -84,8 +84,8 @@ jobs:
           /home/runner/work/vpc-file-storage-mount-helper/vpc-file-storage-mount-helper/${{ matrix.package_dir }}/mount.ibmshare-latest.tar.gz.sha256
           /home/runner/work/vpc-file-storage-mount-helper/vpc-file-storage-mount-helper/mount-helper-container/mount-helper-container-latest.tar.gz
           /home/runner/work/vpc-file-storage-mount-helper/vpc-file-storage-mount-helper/mount-helper-container/mount-helper-container-latest.tar.gz.sha256
-        tag_name: 0.2.7
-        name: 0.2.7
+        tag_name: 0.2.8
+        name: 0.2.8
         body: |
           - Fixed an issue where the installation of the mount helper package would fail in case of update.
     - name: Initialize CodeQL

--- a/mount-helper-container/Makefile
+++ b/mount-helper-container/Makefile
@@ -18,7 +18,7 @@ export LINT_VERSION="1.43.0"
 GOPACKAGES=$(shell go list ./... | grep -v /vendor/ | grep -v /tests)
 
 NAME := mount-helper-container
-APP_VERSION := 0.1.5
+APP_VERSION := 0.1.6
 MAINTAINER := "IKS Storage"
 DESCRIPTION := "IBM Mount-helper-container service"
 LICENSE := "IBM"

--- a/mount-helper-container/Makefile
+++ b/mount-helper-container/Makefile
@@ -18,7 +18,7 @@ export LINT_VERSION="1.43.0"
 GOPACKAGES=$(shell go list ./... | grep -v /vendor/ | grep -v /tests)
 
 NAME := mount-helper-container
-APP_VERSION := 0.1.4
+APP_VERSION := 0.1.5
 MAINTAINER := "IKS Storage"
 DESCRIPTION := "IBM Mount-helper-container service"
 LICENSE := "IBM"
@@ -96,8 +96,7 @@ rpm-build: build-linux
 	echo "/bin/systemctl start mount-helper-container.service >/dev/null 2>&1 || true" >> $(REDHAT_SPEC)
 
 	echo "%preun" >> $(REDHAT_SPEC)
-	echo "systemctl stop mount-helper-container.service || true" >> $(REDHAT_SPEC)
-	echo "systemctl disable mount-helper-container.service || true" >> $(REDHAT_SPEC)
+	echo "%systemd_preun mount-helper-container.service" >> $(REDHAT_SPEC)
 
 	# Build RPM
 	rpmbuild -ba --define "_topdir $(PWD)/$(BUILD_DIR)/rpm" \

--- a/mount-helper-container/README.md
+++ b/mount-helper-container/README.md
@@ -26,6 +26,7 @@ This is a REST based mount-helper-container service which is used for mounting E
 | 0.1.2 | mount.ibmshare-0.1.7 | v0.2.1 | August 5, 2025 | - Fixed bug in deb control file |
 | 0.1.3 | mount.ibmshare-0.1.8 | v0.2.2 | Sep 1, 2025 | - Add offline packages support for RHEL 9.5 |
 | 0.1.4 | mount.ibmshare-0.1.9 | v0.2.2 | March 18, 2026 | - Add stunnel support |
+| 0.1.5 | mount.ibmshare-0.1.9 | v0.2.2 | June 18, 2026 | - Bug fix |
 
 ## Package Building
 


### PR DESCRIPTION
- Script sometimes hangs for RHEL OS:
```
Uninstalling (mount-helper-container.x86_64)...
Removed "/etc/systemd/system/multi-user.target.wants/mount-helper-container.service"
```
- The issue is happening here
```
spec%preun
systemctl stop mount-helper-container.service || true
systemctl disable mount-helper-container.service || true
```
- When we run `chroot /host rpm -e` runs, it executes %preun first. Inside chroot /host, systemctl stop tries to communicate with systemd over D-Bus, which is not reliably available in the chroot context, causing it to hang indefinitely.
- Internally command does
```
if [ $1 -eq 0 ] ; then
    systemctl --no-reload disable --now mount-helper-container.service &>/dev/null || true
fi
```